### PR TITLE
Fix color of SVG path when add-sticky-note div is clicked

### DIFF
--- a/sticky-notes/index.js
+++ b/sticky-notes/index.js
@@ -6,6 +6,10 @@ const availableIds = Array.from(Array(maxNumberOfStickyNotes).keys());
 
 document.addEventListener("DOMContentLoaded", function () {
   const addStickyNoteIconDiv = document.getElementById("add-sticky-note");
+  addStickyNoteIconDiv.addEventListener(
+    "mousedown",
+    changeStickyNoteSVGIconColor
+  );
   addStickyNoteIconDiv.addEventListener("click", addStickyNoteIconClickHandler);
 });
 
@@ -108,4 +112,18 @@ function addStickyNoteIconClickHandler(event) {
   if (availableIds.length != 0) {
     createStickyNote();
   }
+}
+
+function changeStickyNoteSVGIconColor() {
+  const addStickyNotePath = document.getElementById("add-sticky-note-path");
+  const colorOfNextStickyNote = Array.from(addStickyNotePath.classList)[0];
+
+  // Get the root element
+  const root = document.documentElement;
+
+  // Set the value of the CSS variable
+  root.style.setProperty(
+    "--color-active-svg",
+    `var(--color-${colorOfNextStickyNote}-dark)`
+  );
 }

--- a/sticky-notes/style.css
+++ b/sticky-notes/style.css
@@ -20,6 +20,7 @@
   --color-blue-dark: #93c4c7;
   --color-green: #74ed4b;
   --color-green-dark: #6bd149;
+  --color-active-svg: var(--color-yellow-dark);
 }
 
 .sticky-note {
@@ -56,7 +57,7 @@
 }
 
 #add-sticky-note:active > svg > path {
-  fill: var(--color-orange-dark);
+  fill: var(--color-active-svg);
 }
 
 .sticky-note-header {


### PR DESCRIPTION
# Changes in this PR 

This PR fixes the bug in the color of the sticky note SVG path (`<path id="add-sticky-note-path>`) when it is clicked on (`active` state). 

## Cause of bug

The fill of the SVG path is set to 1 color, via the following CSS styling:

```css
#add-sticky-note:active > svg > path {
  fill: var(--color-orange-dark);
}
```

## Changes made 

A new CSS variable `color-active-svg` is created that will be used to set the fill color of the SVG path. This CSS variable will then be programmatically set to the correct corresponding darker color.

# Commits

- Fix color of SVG path when add-sticky-note div is clicked