### PR TITLE
Sticky notes backend

### DIFF
--- a/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/settings.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/settings.py
@@ -140,5 +140,9 @@ CSRF_TRUSTED_ORIGINS = ["http://localhost:3000"]
 REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": [
         "rest_framework.permissions.IsAuthenticatedOrReadOnly"
-    ]
+    ],
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "rest_framework.authentication.SessionAuthentication",
+        "rest_framework.authentication.TokenAuthentication",
+    ],
 }

--- a/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/settings.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/settings.py
@@ -37,11 +37,16 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django.contrib.sites",
     # 3rd party
     "rest_framework",
     "corsheaders",
     "rest_framework.authtoken",
     "dj_rest_auth",
+    "allauth",
+    "allauth.account",
+    "allauth.socialaccount",
+    "dj_rest_auth.registration",
     # local
     "stickynotes.apps.StickynotesConfig",
 ]
@@ -55,6 +60,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "allauth.account.middleware.AccountMiddleware",
 ]
 
 ROOT_URLCONF = "sticky_notes_backend.urls"
@@ -147,3 +153,9 @@ REST_FRAMEWORK = {
         "rest_framework.authentication.TokenAuthentication",
     ],
 }
+
+# allauth settings
+
+EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+
+SITE_ID = 1

--- a/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/settings.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/settings.py
@@ -40,6 +40,7 @@ INSTALLED_APPS = [
     # 3rd party
     "rest_framework",
     "corsheaders",
+    "rest_framework.authtoken",
     # local
     "stickynotes.apps.StickynotesConfig",
 ]

--- a/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/settings.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/settings.py
@@ -128,6 +128,8 @@ STATIC_URL = "static/"
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
+# CORS / CSRF settings
+
 CORS_ALLOWED_ORIGINS = ["http://localhost:3000", "http://localhost:8000"]
 
 CSRF_TRUSTED_ORIGINS = ["http://localhost:3000"]

--- a/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/settings.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/settings.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.2/ref/settings/
 """
 
+from datetime import timedelta
 from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -149,8 +150,17 @@ REST_FRAMEWORK = {
         "rest_framework.permissions.IsAuthenticatedOrReadOnly"
     ],
     "DEFAULT_AUTHENTICATION_CLASSES": [
-        "rest_framework.authentication.TokenAuthentication",
+        "rest_framework_simplejwt.authentication.JWTAuthentication",
     ],
+}
+
+REST_AUTH = {
+    "USE_JWT": True,
+}
+
+SIMPLE_JWT = {
+    "ACCESS_TOKEN_LIFETIME": timedelta(minutes=30),
+    "REFRESH_TOKEN_LIFETIME": timedelta(days=1),
 }
 
 # allauth settings

--- a/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/settings.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/settings.py
@@ -149,7 +149,6 @@ REST_FRAMEWORK = {
         "rest_framework.permissions.IsAuthenticatedOrReadOnly"
     ],
     "DEFAULT_AUTHENTICATION_CLASSES": [
-        "rest_framework.authentication.SessionAuthentication",
         "rest_framework.authentication.TokenAuthentication",
     ],
 }

--- a/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/settings.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/settings.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = [
     "rest_framework",
     "corsheaders",
     "rest_framework.authtoken",
+    "dj_rest_auth",
     # local
     "stickynotes.apps.StickynotesConfig",
 ]

--- a/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/settings.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/settings.py
@@ -133,3 +133,11 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 CORS_ALLOWED_ORIGINS = ["http://localhost:3000", "http://localhost:8000"]
 
 CSRF_TRUSTED_ORIGINS = ["http://localhost:3000"]
+
+# Rest Framework
+
+REST_FRAMEWORK = {
+    "DEFAULT_PERMISSION_CLASSES": [
+        "rest_framework.permissions.IsAuthenticatedOrReadOnly"
+    ]
+}

--- a/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/settings.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/settings.py
@@ -154,9 +154,7 @@ REST_FRAMEWORK = {
     ],
 }
 
-REST_AUTH = {
-    "USE_JWT": True,
-}
+REST_AUTH = {"USE_JWT": True, "JWT_AUTH_HTTPONLY": False}
 
 SIMPLE_JWT = {
     "ACCESS_TOKEN_LIFETIME": timedelta(minutes=30),

--- a/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/urls.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/urls.py
@@ -20,6 +20,7 @@ from django.urls import include, path
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    # enables log in for the Browsable APIs
     path("api-auth/", include("rest_framework.urls")),
     path("api/dj-rest-auth/", include("dj_rest_auth.urls")),
     path("api/dj-rest-auth/registration/", include("dj_rest_auth.registration.urls")),

--- a/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/urls.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/urls.py
@@ -20,5 +20,6 @@ from django.urls import include, path
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("api-auth/", include("rest_framework.urls")),
     path("api/", include("stickynotes.urls")),
 ]

--- a/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/urls.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/urls.py
@@ -22,5 +22,6 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("api-auth/", include("rest_framework.urls")),
     path("api/dj-rest-auth/", include("dj_rest_auth.urls")),
+    path("api/dj-rest-auth/registration/", include("dj_rest_auth.registration.urls")),
     path("api/", include("stickynotes.urls")),
 ]

--- a/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/urls.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/urls.py
@@ -17,6 +17,10 @@ Including another URLconf
 
 from django.contrib import admin
 from django.urls import include, path
+from rest_framework_simplejwt.views import (
+    TokenObtainPairView,
+    TokenRefreshView,
+)
 
 urlpatterns = [
     path("admin/", admin.site.urls),
@@ -24,5 +28,7 @@ urlpatterns = [
     path("api-auth/", include("rest_framework.urls")),
     path("api/dj-rest-auth/", include("dj_rest_auth.urls")),
     path("api/dj-rest-auth/registration/", include("dj_rest_auth.registration.urls")),
+    path("api/token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
+    path("api/token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
     path("api/", include("stickynotes.urls")),
 ]

--- a/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/urls.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/urls.py
@@ -21,5 +21,6 @@ from django.urls import include, path
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("api-auth/", include("rest_framework.urls")),
+    path("api/dj-rest-auth/", include("dj_rest_auth.urls")),
     path("api/", include("stickynotes.urls")),
 ]

--- a/sticky-notes-fullstack/sticky_notes_backend/stickynotes/models.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/stickynotes/models.py
@@ -1,8 +1,10 @@
 from django.db import models
+from django.contrib.auth.models import User
 
 
 class Note(models.Model):
     text = models.CharField(max_length=128)
+    author = models.ForeignKey(to=User, on_delete=models.CASCADE)
     x_pixels_coord = models.IntegerField()
     y_pixels_coord = models.IntegerField()
 

--- a/sticky-notes-fullstack/sticky_notes_backend/stickynotes/permissions.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/stickynotes/permissions.py
@@ -1,0 +1,14 @@
+from rest_framework import permissions
+
+
+class IsAuthorOrReadOnly(permissions.BasePermission):
+    def has_permission(self, request, view):
+        if request.user.is_authenticated:
+            return True
+        return False
+
+    def has_object_permission(self, request, view, obj):
+        if request.method in permissions.SAFE_METHODS:
+            return True
+
+        return obj.author == request.user

--- a/sticky-notes-fullstack/sticky_notes_backend/stickynotes/permissions.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/stickynotes/permissions.py
@@ -12,3 +12,16 @@ class IsAuthorOrReadOnly(permissions.BasePermission):
             return True
 
         return obj.author == request.user
+
+
+class IsUserOrReadOnly(permissions.BasePermission):
+    def has_permission(self, request, view):
+        if request.user.is_authenticated:
+            return True
+        return False
+
+    def has_object_permission(self, request, view, obj):
+        if request.method in permissions.SAFE_METHODS:
+            return True
+
+        return obj == request.user

--- a/sticky-notes-fullstack/sticky_notes_backend/stickynotes/serializers.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/stickynotes/serializers.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.models import User
 from rest_framework import serializers
 
 from .models import Note
@@ -7,3 +8,9 @@ class NoteSerializer(serializers.ModelSerializer):
     class Meta:
         model = Note
         fields = ("id", "text", "author", "x_pixels_coord", "y_pixels_coord")
+
+
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ("id", "username")

--- a/sticky-notes-fullstack/sticky_notes_backend/stickynotes/serializers.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/stickynotes/serializers.py
@@ -6,4 +6,4 @@ from .models import Note
 class NoteSerializer(serializers.ModelSerializer):
     class Meta:
         model = Note
-        fields = ("id", "text", "x_pixels_coord", "y_pixels_coord")
+        fields = ("id", "text", "author", "x_pixels_coord", "y_pixels_coord")

--- a/sticky-notes-fullstack/sticky_notes_backend/stickynotes/serializers.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/stickynotes/serializers.py
@@ -5,6 +5,8 @@ from .models import Note
 
 
 class NoteSerializer(serializers.ModelSerializer):
+    author = serializers.ReadOnlyField(source="author.username")
+
     class Meta:
         model = Note
         fields = ("id", "text", "author", "x_pixels_coord", "y_pixels_coord")

--- a/sticky-notes-fullstack/sticky_notes_backend/stickynotes/tests.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/stickynotes/tests.py
@@ -34,6 +34,13 @@ class APITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertContains(response, self.note.text)
 
+    def test_api_authornoteslistview(self):
+        response = self.client.get(
+            reverse("author_notes_list", kwargs={"pk": self.author.id}), format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertContains(response, self.note.text)
+
     def test_api_authordetailview(self):
         response = self.client.get(
             reverse("author_detail", kwargs={"pk": self.author.id}), format="json"

--- a/sticky-notes-fullstack/sticky_notes_backend/stickynotes/tests.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/stickynotes/tests.py
@@ -14,12 +14,12 @@ class APITests(APITestCase):
             text="This is my 1st sticky note", x_pixels_coord=120, y_pixels_coord=200
         )
 
-    def test_api_listview(self):
+    def test_api_notelistview(self):
         response = self.client.get(reverse("note_list"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertContains(response, self.note.text)
 
-    def test_api_detailview(self):
+    def test_api_notedetailview(self):
         response = self.client.get(
             reverse("note_detail", kwargs={"pk": self.note.id}), format="json"
         )

--- a/sticky-notes-fullstack/sticky_notes_backend/stickynotes/tests.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/stickynotes/tests.py
@@ -33,3 +33,10 @@ class APITests(APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertContains(response, self.note.text)
+
+    def test_api_authordetailview(self):
+        response = self.client.get(
+            reverse("author_detail", kwargs={"pk": self.author.id}), format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertContains(response, self.author.username)

--- a/sticky-notes-fullstack/sticky_notes_backend/stickynotes/tests.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/stickynotes/tests.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.models import User
 from django.test import TestCase
 from django.urls import reverse
 from rest_framework import status
@@ -10,8 +11,15 @@ from .models import Note
 class APITests(APITestCase):
     @classmethod
     def setUpTestData(cls):
+        cls.author = User.objects.create(
+            username="testuser", password="samplepassword123"
+        )
+
         cls.note = Note.objects.create(
-            text="This is my 1st sticky note", x_pixels_coord=120, y_pixels_coord=200
+            text="This is my 1st sticky note",
+            author=cls.author,
+            x_pixels_coord=120,
+            y_pixels_coord=200,
         )
 
     def test_api_notelistview(self):

--- a/sticky-notes-fullstack/sticky_notes_backend/stickynotes/urls.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/stickynotes/urls.py
@@ -1,9 +1,9 @@
 from django.urls import path
 
-from .views import ListNote, DetailNote, DetailAuthor
+from .views import ListNote, DetailNote, ListAuthor
 
 urlpatterns = [
     path(route="notes/", view=ListNote.as_view(), name="note_list"),
     path(route="notes/<int:pk>/", view=DetailNote.as_view(), name="note_detail"),
-    path(route="author/<int:pk>/", view=DetailAuthor.as_view(), name="author_detail"),
+    path(route="author/", view=ListAuthor.as_view(), name="author_detail"),
 ]

--- a/sticky-notes-fullstack/sticky_notes_backend/stickynotes/urls.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/stickynotes/urls.py
@@ -1,12 +1,9 @@
 from django.urls import path
 
-from .views import ListNote, DetailNote, listAuthorNotes, DetailAuthor
+from .views import ListNote, DetailNote, DetailAuthor
 
 urlpatterns = [
     path(route="notes/", view=ListNote.as_view(), name="note_list"),
     path(route="notes/<int:pk>/", view=DetailNote.as_view(), name="note_detail"),
-    path(
-        route="author/<int:pk>/notes/", view=listAuthorNotes, name="author_notes_list"
-    ),
     path(route="author/<int:pk>/", view=DetailAuthor.as_view(), name="author_detail"),
 ]

--- a/sticky-notes-fullstack/sticky_notes_backend/stickynotes/urls.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/stickynotes/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
 
-from .views import ListNote, DetailNote
+from .views import ListNote, DetailNote, DetailAuthor
 
 urlpatterns = [
     path(route="notes/", view=ListNote.as_view(), name="note_list"),
     path(route="note/<int:pk>/", view=DetailNote.as_view(), name="note_detail"),
+    path(route="author/<int:pk>/", view=DetailAuthor.as_view(), name="author_detail"),
 ]

--- a/sticky-notes-fullstack/sticky_notes_backend/stickynotes/urls.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/stickynotes/urls.py
@@ -1,9 +1,12 @@
 from django.urls import path
 
-from .views import ListNote, DetailNote, DetailAuthor
+from .views import ListNote, DetailNote, listAuthorNotes, DetailAuthor
 
 urlpatterns = [
     path(route="notes/", view=ListNote.as_view(), name="note_list"),
     path(route="note/<int:pk>/", view=DetailNote.as_view(), name="note_detail"),
+    path(
+        route="author/<int:pk>/notes/", view=listAuthorNotes, name="author_notes_list"
+    ),
     path(route="author/<int:pk>/", view=DetailAuthor.as_view(), name="author_detail"),
 ]

--- a/sticky-notes-fullstack/sticky_notes_backend/stickynotes/urls.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/stickynotes/urls.py
@@ -4,7 +4,7 @@ from .views import ListNote, DetailNote, listAuthorNotes, DetailAuthor
 
 urlpatterns = [
     path(route="notes/", view=ListNote.as_view(), name="note_list"),
-    path(route="note/<int:pk>/", view=DetailNote.as_view(), name="note_detail"),
+    path(route="notes/<int:pk>/", view=DetailNote.as_view(), name="note_detail"),
     path(
         route="author/<int:pk>/notes/", view=listAuthorNotes, name="author_notes_list"
     ),

--- a/sticky-notes-fullstack/sticky_notes_backend/stickynotes/views.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/stickynotes/views.py
@@ -20,6 +20,10 @@ class ListNote(generics.ListCreateAPIView):
     def get_queryset(self):
         return Note.objects.filter(author=self.request.user)
 
+    def perform_create(self, serializer):
+        serializer.save(author=self.request.user)
+
+
 class DetailNote(generics.RetrieveUpdateDestroyAPIView):
     permission_classes = (IsAuthorOrReadOnly,)
     queryset = Note.objects.all()

--- a/sticky-notes-fullstack/sticky_notes_backend/stickynotes/views.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/stickynotes/views.py
@@ -9,7 +9,7 @@ from django.http import HttpResponse, JsonResponse
 from django.shortcuts import render
 
 from .models import Note
-from .serializers import NoteSerializer
+from .serializers import NoteSerializer, UserSerializer
 
 
 class ListNote(generics.ListCreateAPIView):
@@ -52,4 +52,4 @@ def listAuthorNotes(request, pk):
 
 class DetailAuthor(generics.RetrieveUpdateDestroyAPIView):
     queryset = User.objects.all()
-    serializer_class = NoteSerializer
+    serializer_class = UserSerializer

--- a/sticky-notes-fullstack/sticky_notes_backend/stickynotes/views.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/stickynotes/views.py
@@ -1,5 +1,5 @@
 from rest_framework import generics, status
-from rest_framework.decorators import api_view
+from rest_framework.decorators import api_view, permission_classes
 from rest_framework.parsers import JSONParser
 from rest_framework.response import Response
 
@@ -9,6 +9,7 @@ from django.http import HttpResponse, JsonResponse
 from django.shortcuts import render
 
 from .models import Note
+from .permissions import IsAuthorOrReadOnly
 from .serializers import NoteSerializer, UserSerializer
 
 
@@ -23,6 +24,7 @@ class DetailNote(generics.RetrieveUpdateDestroyAPIView):
 
 
 @api_view(["GET", "POST"])
+@permission_classes([IsAuthorOrReadOnly])
 def listAuthorNotes(request, pk):
     try:
         author = User.objects.get(id=pk)

--- a/sticky-notes-fullstack/sticky_notes_backend/stickynotes/views.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/stickynotes/views.py
@@ -23,6 +23,9 @@ class DetailNote(generics.RetrieveUpdateDestroyAPIView):
     queryset = Note.objects.all()
     serializer_class = NoteSerializer
 
+    def perform_update(self, serializer):
+        serializer.save(author=self.request.user)
+
 
 class ListAuthor(generics.ListCreateAPIView):
     permission_classes = (IsUserOrReadOnly,)

--- a/sticky-notes-fullstack/sticky_notes_backend/stickynotes/views.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/stickynotes/views.py
@@ -9,7 +9,7 @@ from django.http import HttpResponse, JsonResponse
 from django.shortcuts import render
 
 from .models import Note
-from .permissions import IsAuthorOrReadOnly
+from .permissions import IsAuthorOrReadOnly, IsUserOrReadOnly
 from .serializers import NoteSerializer, UserSerializer
 
 
@@ -54,5 +54,6 @@ def listAuthorNotes(request, pk):
 
 
 class DetailAuthor(generics.RetrieveUpdateDestroyAPIView):
+    permission_classes = (IsUserOrReadOnly,)
     queryset = User.objects.all()
     serializer_class = UserSerializer

--- a/sticky-notes-fullstack/sticky_notes_backend/stickynotes/views.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/stickynotes/views.py
@@ -24,7 +24,9 @@ class DetailNote(generics.RetrieveUpdateDestroyAPIView):
     serializer_class = NoteSerializer
 
 
-class DetailAuthor(generics.RetrieveUpdateDestroyAPIView):
+class ListAuthor(generics.ListCreateAPIView):
     permission_classes = (IsUserOrReadOnly,)
-    queryset = User.objects.all()
     serializer_class = UserSerializer
+
+    def get_queryset(self):
+        return User.objects.filter(id=self.request.user.id)

--- a/sticky-notes-fullstack/sticky_notes_backend/stickynotes/views.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/stickynotes/views.py
@@ -24,35 +24,6 @@ class DetailNote(generics.RetrieveUpdateDestroyAPIView):
     serializer_class = NoteSerializer
 
 
-@api_view(["GET", "POST"])
-@permission_classes([IsAuthorOrReadOnly])
-def listAuthorNotes(request, pk):
-    try:
-        author = User.objects.get(id=pk)
-    except User.DoesNotExist:
-        return Response(
-            {"detail": "No such User exists"}, status=status.HTTP_404_NOT_FOUND
-        )
-    except User.MultipleObjectsReturned:
-        return Response(
-            {"detail": "Multiple Users with the same id exists"},
-            status=status.HTTP_404_NOT_FOUND,
-        )
-
-    if request.method == "GET":
-        notes = Note.objects.filter(author=author)
-        serializer = NoteSerializer(notes, many=True)
-        return JsonResponse(serializer.data, safe=False)
-
-    if request.method == "POST":
-        data = JSONParser().parse(request)
-        serializer = NoteSerializer(data=data)
-        if serializer.is_valid():
-            serializer.save()
-            return JsonResponse(serializer.data, status=201)
-        return JsonResponse(serializer.errors, status=400)
-
-
 class DetailAuthor(generics.RetrieveUpdateDestroyAPIView):
     permission_classes = (IsUserOrReadOnly,)
     queryset = User.objects.all()

--- a/sticky-notes-fullstack/sticky_notes_backend/stickynotes/views.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/stickynotes/views.py
@@ -15,9 +15,10 @@ from .serializers import NoteSerializer, UserSerializer
 
 class ListNote(generics.ListCreateAPIView):
     permission_classes = (IsAuthorOrReadOnly,)
-    queryset = Note.objects.all()
     serializer_class = NoteSerializer
 
+    def get_queryset(self):
+        return Note.objects.filter(author=self.request.user)
 
 class DetailNote(generics.RetrieveUpdateDestroyAPIView):
     permission_classes = (IsAuthorOrReadOnly,)

--- a/sticky-notes-fullstack/sticky_notes_backend/stickynotes/views.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/stickynotes/views.py
@@ -1,7 +1,11 @@
-from rest_framework import generics
+from rest_framework import generics, status
+from rest_framework.decorators import api_view
+from rest_framework.parsers import JSONParser
+from rest_framework.response import Response
 
 from django.contrib.auth.models import User
-from django.http import HttpResponse
+
+from django.http import HttpResponse, JsonResponse
 from django.shortcuts import render
 
 from .models import Note
@@ -16,6 +20,34 @@ class ListNote(generics.ListCreateAPIView):
 class DetailNote(generics.RetrieveUpdateDestroyAPIView):
     queryset = Note.objects.all()
     serializer_class = NoteSerializer
+
+
+@api_view(["GET", "POST"])
+def listAuthorNotes(request, pk):
+    try:
+        author = User.objects.get(id=pk)
+    except User.DoesNotExist:
+        return Response(
+            {"detail": "No such User exists"}, status=status.HTTP_404_NOT_FOUND
+        )
+    except User.MultipleObjectsReturned:
+        return Response(
+            {"detail": "Multiple Users with the same id exists"},
+            status=status.HTTP_404_NOT_FOUND,
+        )
+
+    if request.method == "GET":
+        notes = Note.objects.filter(author=author)
+        serializer = NoteSerializer(notes, many=True)
+        return JsonResponse(serializer.data, safe=False)
+
+    if request.method == "POST":
+        data = JSONParser().parse(request)
+        serializer = NoteSerializer(data=data)
+        if serializer.is_valid():
+            serializer.save()
+            return JsonResponse(serializer.data, status=201)
+        return JsonResponse(serializer.errors, status=400)
 
 
 class DetailAuthor(generics.RetrieveUpdateDestroyAPIView):

--- a/sticky-notes-fullstack/sticky_notes_backend/stickynotes/views.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/stickynotes/views.py
@@ -14,6 +14,7 @@ from .serializers import NoteSerializer, UserSerializer
 
 
 class ListNote(generics.ListCreateAPIView):
+    permission_classes = (IsAuthorOrReadOnly,)
     queryset = Note.objects.all()
     serializer_class = NoteSerializer
 

--- a/sticky-notes-fullstack/sticky_notes_backend/stickynotes/views.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/stickynotes/views.py
@@ -19,6 +19,7 @@ class ListNote(generics.ListCreateAPIView):
 
 
 class DetailNote(generics.RetrieveUpdateDestroyAPIView):
+    permission_classes = (IsAuthorOrReadOnly,)
     queryset = Note.objects.all()
     serializer_class = NoteSerializer
 

--- a/sticky-notes-fullstack/sticky_notes_backend/stickynotes/views.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/stickynotes/views.py
@@ -1,5 +1,6 @@
 from rest_framework import generics
 
+from django.contrib.auth.models import User
 from django.http import HttpResponse
 from django.shortcuts import render
 
@@ -14,4 +15,9 @@ class ListNote(generics.ListCreateAPIView):
 
 class DetailNote(generics.RetrieveUpdateDestroyAPIView):
     queryset = Note.objects.all()
+    serializer_class = NoteSerializer
+
+
+class DetailAuthor(generics.RetrieveUpdateDestroyAPIView):
+    queryset = User.objects.all()
     serializer_class = NoteSerializer


### PR DESCRIPTION
# Changes in this PR 

This PR includes the following changes:

- Add `dj-rest-auth` to `sticky_notes_backend` Django project
- Add `djangorestframework-simplejwt` to `sticky_notes_backend` Django project 
- Add `django-allauth` to `sticky_notes_backend` Django project
- Add `author` field for `Note` model 
- Define `IsAuthorOrReadOnly` & `IsUserOrReadOnly` permissions in `permissions.py` 
- Update `NoteSerializer` to reflect `author` field of a serialized `Note` object
- Define `UserSerializer` serializer 
- Update tests to include new `author` field 
- Refactor `note/<int:pk>/` endpoint to `notes/<int:pk>/`
- Add `author` endpoint to retrieve details of the user
- Add `IsAuthorOrReadOnly` permissions to `ListNote` & `DetailNote` views, `IsUserOrReadOnly` permission to `DetailNote` view

