### PR TITLE
Adding requirements.txt, `README.md` & modifying DetailNote view behavior

### DIFF
--- a/sticky-notes-fullstack/sticky_notes_backend/README.md
+++ b/sticky-notes-fullstack/sticky_notes_backend/README.md
@@ -1,0 +1,27 @@
+# sticky_notes_backend Django backend
+
+## Setup
+
+Create a virtual environment using the provided `requirements.txt`.
+
+Start the virtual environment by running below command:
+
+```shell
+# macOS / Linux
+source sticky-notes-backend/bin/Activate
+```
+
+## Superuser Credentials
+
+```
+username: haikal
+email: haikal@gmail.com
+password: password
+```
+
+## Other sample credentials
+
+```
+username: testuser
+password: passwordabc123
+```

--- a/sticky-notes-fullstack/sticky_notes_backend/requirements.txt
+++ b/sticky-notes-fullstack/sticky_notes_backend/requirements.txt
@@ -1,0 +1,15 @@
+asgiref==3.8.1
+certifi==2024.2.2
+charset-normalizer==3.3.2
+dj-rest-auth==6.0.0
+Django==4.2.11
+django-allauth==0.62.1
+django-cors-headers==4.3.1
+djangorestframework==3.15.1
+djangorestframework-simplejwt==5.3.1
+idna==3.7
+PyJWT==2.8.0
+requests==2.31.0
+sqlparse==0.5.0
+tzdata==2024.1
+urllib3==2.2.1

--- a/sticky-notes-fullstack/sticky_notes_backend/stickynotes/permissions.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/stickynotes/permissions.py
@@ -8,9 +8,6 @@ class IsAuthorOrReadOnly(permissions.BasePermission):
         return False
 
     def has_object_permission(self, request, view, obj):
-        if request.method in permissions.SAFE_METHODS:
-            return True
-
         return obj.author == request.user
 
 


### PR DESCRIPTION
# Changes in this PR 

This PR includes the following changes:

- Adding `requirements.txt`

## Adding `requirements.txt`

A `requirements.txt` file is added to list the packages needed to run the `sticky_notes_backend` Django project. 

## Adding `README.md`

A `README.md` is created in `sticky_notes_backend` to explain the project setup & credentials used.

## Modifying `DetailNote` view behavior

The `DetailNote` view behavior is modified to only allow the author of a `Note` to view its details. 

The `DetailNote` view uses the `IsAuthorOrReadOnly` permission:

```py
class DetailNote(generics.RetrieveUpdateDestroyAPIView):
    permission_classes = (IsAuthorOrReadOnly,)
    ...
```

The `has_object_permission` method of `IsAuthorOrReadOnly` permission class was modified from:

```py
def has_object_permission(self, request, view, obj):
    if request.method in permissions.SAFE_METHODS:
        return True
    return obj.author == request.user
```

to

```py
def has_object_permission(self, request, view, obj):
    return obj.author == request.user
```