### PR TITLE
Add API schema documentation

### DIFF
--- a/sticky-notes-fullstack/sticky_notes_backend/requirements.txt
+++ b/sticky-notes-fullstack/sticky_notes_backend/requirements.txt
@@ -1,4 +1,5 @@
 asgiref==3.8.1
+attrs==23.2.0
 certifi==2024.2.2
 charset-normalizer==3.3.2
 dj-rest-auth==6.0.0
@@ -7,9 +8,17 @@ django-allauth==0.62.1
 django-cors-headers==4.3.1
 djangorestframework==3.15.1
 djangorestframework-simplejwt==5.3.1
+drf-spectacular==0.27.2
 idna==3.7
+inflection==0.5.1
+jsonschema==4.22.0
+jsonschema-specifications==2023.12.1
 PyJWT==2.8.0
+PyYAML==6.0.1
+referencing==0.35.1
 requests==2.31.0
+rpds-py==0.18.1
 sqlparse==0.5.0
 tzdata==2024.1
+uritemplate==4.1.1
 urllib3==2.2.1

--- a/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/settings.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/settings.py
@@ -153,6 +153,7 @@ REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework_simplejwt.authentication.JWTAuthentication",
     ],
+    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
 }
 
 REST_AUTH = {"USE_JWT": True, "JWT_AUTH_HTTPONLY": False}

--- a/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/settings.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/settings.py
@@ -168,3 +168,11 @@ SIMPLE_JWT = {
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
 SITE_ID = 1
+
+# Metadata for OpenAPI
+
+SPECTACULAR_SETTINGS = {
+    "TITLE": "Blog API Project",
+    "DESCRIPTION": "A sample blog to learn about DRF",
+    "VERSION": "1.0.0",
+}

--- a/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/settings.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/settings.py
@@ -48,6 +48,7 @@ INSTALLED_APPS = [
     "allauth.account",
     "allauth.socialaccount",
     "dj_rest_auth.registration",
+    "drf_spectacular",
     # local
     "stickynotes.apps.StickynotesConfig",
 ]

--- a/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/urls.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/urls.py
@@ -17,6 +17,7 @@ Including another URLconf
 
 from django.contrib import admin
 from django.urls import include, path
+from drf_spectacular.views import SpectacularAPIView
 from rest_framework_simplejwt.views import (
     TokenObtainPairView,
     TokenRefreshView,
@@ -31,4 +32,6 @@ urlpatterns = [
     path("api/token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
     path("api/token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
     path("api/", include("stickynotes.urls")),
+    # endpoints to generate schema file (schema.yml)
+    path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
 ]

--- a/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/urls.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/urls.py
@@ -32,8 +32,9 @@ urlpatterns = [
     path("api/token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
     path("api/token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
     path("api/", include("stickynotes.urls")),
-    # endpoints to generate schema file (schema.yml)
+    # endpoint to generate schema file (schema.yml)
     path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
+    # endpoint for SwaggerUI documentation
     path(
         "api/schema/swagger-ui/",
         SpectacularSwaggerView.as_view(url_name="schema"),

--- a/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/urls.py
+++ b/sticky-notes-fullstack/sticky_notes_backend/sticky_notes_backend/urls.py
@@ -17,7 +17,7 @@ Including another URLconf
 
 from django.contrib import admin
 from django.urls import include, path
-from drf_spectacular.views import SpectacularAPIView
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 from rest_framework_simplejwt.views import (
     TokenObtainPairView,
     TokenRefreshView,
@@ -34,4 +34,9 @@ urlpatterns = [
     path("api/", include("stickynotes.urls")),
     # endpoints to generate schema file (schema.yml)
     path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
+    path(
+        "api/schema/swagger-ui/",
+        SpectacularSwaggerView.as_view(url_name="schema"),
+        name="swagger-ui",
+    ),
 ]


### PR DESCRIPTION
# Changes in this PR 

This PR includes changes to add API schema documentation to the `sticky_notes_backend` Django project, using the `drf-spectacular` package & the OpenAPI specification.

## Addition of `drf-spectacular` package

The `drf-spectacular` package is added to enable the generation of an OpenAPI 3 schema for the `stciky_notes_backend` Django project.

## Addition of `api/schema` & `api/schema/swagger-ui` endpoints 

The `api/schema/` endpoint is added & automatically generates a `schema.yml` file. 

The `api/schema/swagger-ui/` endpoint is added & generates a SwaggerUI interface that documents the API schema for `sticky_notes_backend` 
