### PR TITLE
Implement custom hook useDrag

### DIFF
--- a/sticky-notes-fullstack/sticky-notes-frontend/src/components/StickyNote.js
+++ b/sticky-notes-fullstack/sticky-notes-frontend/src/components/StickyNote.js
@@ -4,8 +4,8 @@ import "./StickyNote.css";
 
 import useDrag from "../hooks/useDrag";
 
-function StickyNote({ id, color, xCoord, yCoord, children }) {
-  const startingPosition = { startingXCoord: xCoord, startingYCoord: yCoord };
+function StickyNote({ id, color, x, y, children }) {
+  const startingPosition = { startingXCoord: x, startingYCoord: y };
 
   const { picturePosition, handleMouseDown, handleMouseMove, handleMouseUp } =
     useDrag(startingPosition);

--- a/sticky-notes-fullstack/sticky-notes-frontend/src/components/StickyNote.js
+++ b/sticky-notes-fullstack/sticky-notes-frontend/src/components/StickyNote.js
@@ -2,9 +2,13 @@ import { useState } from "react";
 
 import "./StickyNote.css";
 
+import useDrag from "../hooks/useDrag";
+
 function StickyNote({ id, color, xCoord, yCoord, children }) {
-  const [x, setX] = useState(xCoord);
-  const [y, setY] = useState(yCoord);
+  const startingPosition = { startingXCoord: xCoord, startingYCoord: yCoord };
+
+  const { picturePosition, handleMouseDown, handleMouseMove, handleMouseUp } =
+    useDrag(startingPosition);
 
   return (
     <div
@@ -12,9 +16,12 @@ function StickyNote({ id, color, xCoord, yCoord, children }) {
       data-id={`${id}`}
       className={`sticky-note ${color}`}
       style={{
-        top: y,
-        left: x,
+        ...picturePosition,
       }}
+      onMouseDown={handleMouseDown}
+      onMouseMove={handleMouseMove}
+      onMouseLeave={handleMouseMove}
+      onMouseUp={handleMouseUp}
     >
       <div
         id={`sticky-note-${id}-header`}

--- a/sticky-notes-fullstack/sticky-notes-frontend/src/hooks/useDrag.js
+++ b/sticky-notes-fullstack/sticky-notes-frontend/src/hooks/useDrag.js
@@ -1,11 +1,11 @@
 import { useState } from "react";
 
-const useDrag = (startingPosition) => {
+const useDrag = ({ startingXCoord, startingYCoord }) => {
   const [dragInfo, setDragInfo] = useState({
     isDragging: false,
     origin: { x: 0, y: 0 },
-    translation: startingPosition,
-    lastTranslation: startingPosition,
+    translation: { x: startingXCoord, y: startingYCoord },
+    lastTranslation: { x: startingXCoord, y: startingYCoord },
   });
 
   const { isDragging } = dragInfo;

--- a/sticky-notes-fullstack/sticky-notes-frontend/src/hooks/useDrag.js
+++ b/sticky-notes-fullstack/sticky-notes-frontend/src/hooks/useDrag.js
@@ -1,0 +1,60 @@
+import { useState } from "react";
+
+const useDrag = (startingPosition) => {
+  const [dragInfo, setDragInfo] = useState({
+    isDragging: false,
+    origin: { x: 0, y: 0 },
+    translation: startingPosition,
+    lastTranslation: startingPosition,
+  });
+
+  const { isDragging } = dragInfo;
+
+  const handleMouseDown = ({ clientX, clientY }) => {
+    if (!isDragging)
+      setDragInfo({
+        ...dragInfo,
+        isDragging: true,
+        origin: { x: clientX, y: clientY },
+      });
+  };
+
+  const handleMouseMove = ({ clientX, clientY }) => {
+    if (isDragging) {
+      const { origin, lastTranslation } = dragInfo;
+      setDragInfo({
+        ...dragInfo,
+        translation: {
+          x: clientX - origin.x + lastTranslation.x,
+          y: clientY - origin.y + lastTranslation.y,
+        },
+      });
+    }
+  };
+
+  const handleMouseUp = () => {
+    if (isDragging) {
+      const { translation } = dragInfo;
+      setDragInfo({
+        ...dragInfo,
+        isDragging: false,
+        lastTranslation: { x: translation.x, y: translation.y },
+      });
+    }
+  };
+
+  const picturePosition = {
+    position: "absolute",
+    left: `${dragInfo.translation.x}px`,
+    top: `${dragInfo.translation.y}px`,
+  };
+
+  return {
+    picturePosition,
+    handleMouseDown,
+    handleMouseMove,
+    handleMouseUp,
+  };
+};
+
+export default useDrag;


### PR DESCRIPTION
# Changes in this PR 

This PR contains changes to implement a custom hook `useDrag` that makes a component draggable

## `useDrag()` hook 

The `useDrag()` hook takes in an object:

```json
{
   "startingXCoord": integer,
   "startingYCoord": integer
}
```

& returns the following variables:

```
picturePosition: {x: integer, y: integer}
handleMouseDown: an event handler to handle `mouseDown` events
handleMouseMove: an event handler to handle `mouseMove` events
handleMouseUp: an event handler to handle `mouseUp` events
```





