### PR TITLE
Refactor logic for updating color of AddStickyNoteIcon component

### DIFF
--- a/sticky-notes-fullstack/sticky-notes-frontend/src/components/AddStickyNoteIcon.js
+++ b/sticky-notes-fullstack/sticky-notes-frontend/src/components/AddStickyNoteIcon.js
@@ -1,13 +1,19 @@
+import { useState } from "react";
+
 import "./AddStickyNoteIcon.css";
 
 function AddStickyNoteIcon({ stickyNotes, addStickyNotes }) {
+  const [colorOfNextStickyNote, setColorOfNextStickyNote] = useState("yellow");
+
   const addStickyNoteHandler = () => {
     // TODO - Remove hardcoded declaration of StickyNote
     const colors = ["yellow", "orange", "pink", "blue", "green"];
 
+    setColorOfNextStickyNote(colors[Math.floor(Math.random() * colors.length)]);
+
     const newStickyNote = {
       id: Math.random() * 100 + 1,
-      color: colors[Math.floor(Math.random() * colors.length)],
+      color: colorOfNextStickyNote,
       x: 20,
       y: 20,
     };
@@ -24,7 +30,7 @@ function AddStickyNoteIcon({ stickyNotes, addStickyNotes }) {
       >
         <path
           id="add-sticky-note-path"
-          className="yellow"
+          className={colorOfNextStickyNote}
           d="M64 32C28.7 32 0 60.7 0 96V416c0 35.3 28.7 64 64 64H288V368c0-26.5 21.5-48 48-48H448V96c0-35.3-28.7-64-64-64H64zM448 352H402.7 336c-8.8 0-16 7.2-16 16v66.7V480l32-32 64-64 32-32z"
         />
       </svg>


### PR DESCRIPTION
# Changes in this PR 

This PR includes changes to refactor the logic for updating color of `AddStickyNoteIcon` component

## Refactoring logic for updating color of `AddStickyNoteIcon` component

Previously, the color of the `AddStickyNoteIcon` component was hardcoded to start with `"yellow"`. 

And any subsequent changes in the `AddStickyNoteIcon` component's color was not accurately matching the color of the next Sticky Note that will be generated.

This was refactored to use React's `useState` so that the color of the `AddStickyNoteIcon` component is correctly reflected. 

