### PR TITLE
Make AddStickyNoteIcon darker when active

### DIFF
--- a/sticky-notes-fullstack/sticky-notes-frontend/src/App.css
+++ b/sticky-notes-fullstack/sticky-notes-frontend/src/App.css
@@ -30,6 +30,11 @@
   fill: var(--color-yellow);
 }
 
+.yellow-dark {
+  background-color: var(--color-yellow-dark);
+  fill: var(--color-yellow-dark);
+}
+
 .yellow-header {
   background: linear-gradient(
     0deg,
@@ -41,6 +46,11 @@
 .orange {
   background-color: var(--color-orange);
   fill: var(--color-orange);
+}
+
+.orange-dark {
+  background-color: var(--color-orange-dark);
+  fill: var(--color-orange-dark);
 }
 
 .orange-header {
@@ -56,6 +66,11 @@
   fill: var(--color-pink);
 }
 
+.pink-dark {
+  background-color: var(--color-pink-dark);
+  fill: var(--color-pink-dark);
+}
+
 .pink-header {
   background: linear-gradient(
     0deg,
@@ -69,6 +84,11 @@
   fill: var(--color-blue);
 }
 
+.blue-dark {
+  background-color: var(--color-blue-dark);
+  fill: var(--color-blue-dark);
+}
+
 .blue-header {
   background: linear-gradient(
     0deg,
@@ -80,6 +100,11 @@
 .green {
   background-color: var(--color-green);
   fill: var(--color-green);
+}
+
+.green-dark {
+  background-color: var(--color-green-dark);
+  fill: var(--color-green-dark);
 }
 
 .green-header {

--- a/sticky-notes-fullstack/sticky-notes-frontend/src/components/AddStickyNoteIcon.js
+++ b/sticky-notes-fullstack/sticky-notes-frontend/src/components/AddStickyNoteIcon.js
@@ -21,12 +21,26 @@ function AddStickyNoteIcon({ stickyNotes, addStickyNotes }) {
     addStickyNotes([...stickyNotes, newStickyNote]);
   };
 
+  const onMouseDownHandler = () => {
+    setColorOfNextStickyNote((currentColor) => {
+      return `${currentColor}-dark`;
+    });
+  };
+
+  const onMouseUpHandler = () => {
+    setColorOfNextStickyNote((currentColor) => {
+      return `${currentColor.replace("-dark", "")}`;
+    });
+  };
+
   return (
     <div id="add-sticky-note">
       <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 30 448 448"
         onClick={addStickyNoteHandler}
+        onMouseDown={onMouseDownHandler}
+        onMouseUp={onMouseUpHandler}
       >
         <path
           id="add-sticky-note-path"

--- a/sticky-notes-fullstack/sticky-notes-frontend/src/components/StickyNoteContainer.js
+++ b/sticky-notes-fullstack/sticky-notes-frontend/src/components/StickyNoteContainer.js
@@ -3,8 +3,6 @@ import React from "react";
 import StickyNote from "./StickyNote";
 
 function StickyNoteContainer({ stickyNotes }) {
-  console.log("stickyNotes:", stickyNotes);
-
   return (
     <React.Fragment>
       {stickyNotes.map(({ id, color, x, y }) => (


### PR DESCRIPTION
# Changes in this PR 

This PR includes changes to make the `StickyNoteIcon` darker when it is active 

## `StickyNoteIcon` darker when it is active 

The `StickyNoteIcon` will be a darker shade of its current color when it is active (being clicked on / mouse is down). As the color of the `StickyNoteIcon` icon will change after every click, the original logic that set a CSS variable in the root & changing the value of this CSS variable was refactored.

Instead, event handlers for `onMouseDown` & `onMouseUp` events are implemented to mimic the "`active`" CSS pseudo-class. 

## Add `dark` CSS classes for different colors

For all available CSS color classes in `App.css`, the `dark` CSS classes are created to accommodate the `StickyNoteIcon` icon being darker when active.